### PR TITLE
chore: add husky hooks and branch protection

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+sh .husky/scripts/no-commits-on-main.sh
+sh .husky/scripts/no-commits-on-merged-branch.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,7 @@
+sh .husky/scripts/no-direct-push-main.sh
+sh .husky/scripts/branch-name-check.sh
+sh .husky/scripts/uncommitted-files-check.sh
+
+npm run test:run
+
+sh .husky/scripts/check-conflicts-with-main.sh

--- a/.husky/scripts/branch-name-check.sh
+++ b/.husky/scripts/branch-name-check.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Skip check for main
+if [ "$branch" = "main" ]; then
+  exit 0
+fi
+
+# Allowed prefixes: feat/, fix/, refactor/, chore/, docs/, test/, ci/
+valid_pattern="^(feat|fix|refactor|chore|docs|test|ci)/.+"
+
+if ! echo "$branch" | grep -qE "$valid_pattern"; then
+  printf "\n❌ Branch name '%s' does not follow the convention.\n" "$branch"
+  printf "   Use one of: feat/, fix/, refactor/, chore/, docs/, test/, ci/\n"
+  printf "   Example: feat/add-new-rule\n\n"
+  exit 1
+fi

--- a/.husky/scripts/branch-name-check.sh
+++ b/.husky/scripts/branch-name-check.sh
@@ -10,7 +10,7 @@ fi
 # Allowed prefixes: feat/, fix/, refactor/, chore/, docs/, test/, ci/
 valid_pattern="^(feat|fix|refactor|chore|docs|test|ci)/.+"
 
-if ! echo "$branch" | grep -qE "$valid_pattern"; then
+if ! printf '%s' "$branch" | grep -qE "$valid_pattern"; then
   printf "\n❌ Branch name '%s' does not follow the convention.\n" "$branch"
   printf "   Use one of: feat/, fix/, refactor/, chore/, docs/, test/, ci/\n"
   printf "   Example: feat/add-new-rule\n\n"

--- a/.husky/scripts/check-conflicts-with-main.sh
+++ b/.husky/scripts/check-conflicts-with-main.sh
@@ -20,7 +20,8 @@ fi
 # Check for merge conflicts using merge-tree (requires Git 2.38+)
 merge_base="$(git merge-base HEAD origin/main 2>/dev/null)"
 if [ -n "$merge_base" ]; then
-  conflicts="$(git merge-tree --write-tree --no-messages HEAD origin/main 2>&1)" || {
+  # Requires Git 2.38+ for --write-tree/--no-messages flags
+  git merge-tree --write-tree --no-messages HEAD origin/main >/dev/null 2>&1 || {
     printf "\n❌ Your branch has merge conflicts with main.\n"
     printf "   Please rebase and resolve conflicts before pushing:\n"
     printf "   git rebase origin/main\n\n"

--- a/.husky/scripts/check-conflicts-with-main.sh
+++ b/.husky/scripts/check-conflicts-with-main.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Skip check for main
+if [ "$branch" = "main" ]; then
+  exit 0
+fi
+
+# Fetch latest main silently
+git fetch origin main --quiet 2>/dev/null
+
+# Check if branch is behind main
+behind="$(git rev-list --count HEAD..origin/main 2>/dev/null)"
+if [ "$behind" -gt 0 ] 2>/dev/null; then
+  printf "\n⚠️  Your branch is %s commit(s) behind main.\n" "$behind"
+  printf "   Consider rebasing: git rebase origin/main\n\n"
+fi
+
+# Check for merge conflicts using merge-tree (requires Git 2.38+)
+merge_base="$(git merge-base HEAD origin/main 2>/dev/null)"
+if [ -n "$merge_base" ]; then
+  conflicts="$(git merge-tree --write-tree --no-messages HEAD origin/main 2>&1)" || {
+    printf "\n❌ Your branch has merge conflicts with main.\n"
+    printf "   Please rebase and resolve conflicts before pushing:\n"
+    printf "   git rebase origin/main\n\n"
+    exit 1
+  }
+fi

--- a/.husky/scripts/no-commits-on-main.sh
+++ b/.husky/scripts/no-commits-on-main.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "main" ]; then
+  printf "\n❌ Direct commits to main are not allowed.\n"
+  printf "   Create a feature branch instead:\n"
+  printf "   git checkout -b feat/my-feature\n\n"
+  exit 1
+fi

--- a/.husky/scripts/no-commits-on-merged-branch.sh
+++ b/.husky/scripts/no-commits-on-merged-branch.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Skip check for main
+if [ "$branch" = "main" ]; then
+  exit 0
+fi
+
+# Check if a PR exists and is already merged
+pr_state="$(gh pr view "$branch" --json state --jq '.state' 2>/dev/null)"
+
+if [ "$pr_state" = "MERGED" ]; then
+  printf "\n❌ This branch's PR has already been merged.\n"
+  printf "   Create a new branch for further changes:\n"
+  printf "   git checkout main && git pull && git checkout -b feat/new-branch\n\n"
+  exit 1
+fi

--- a/.husky/scripts/no-direct-push-main.sh
+++ b/.husky/scripts/no-direct-push-main.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "main" ]; then
+  printf "\n❌ Direct pushes to main are not allowed.\n"
+  printf "   Push to a feature branch and open a PR instead.\n\n"
+  exit 1
+fi

--- a/.husky/scripts/uncommitted-files-check.sh
+++ b/.husky/scripts/uncommitted-files-check.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -n "$(git status --porcelain)" ]; then
+  printf "\n❌ You have uncommitted changes.\n"
+  printf "   Please commit or stash them before pushing.\n\n"
+  git status --short
+  exit 1
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@typescript-eslint/parser": "^8.56.1",
         "eslint": "^8.57.0",
+        "husky": "^9.1.7",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
       },
@@ -2093,6 +2094,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "test": "vitest",
     "test:run": "vitest --run",
-    "test:cov": "vitest --run --coverage"
+    "test:cov": "vitest --run --coverage",
+    "prepare": "husky"
   },
   "peerDependencies": {
     "eslint": ">=8.0.0"
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@typescript-eslint/parser": "^8.56.1",
     "eslint": "^8.57.0",
+    "husky": "^9.1.7",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0"
   },


### PR DESCRIPTION
## Summary
- Add husky git hooks inspired by TiedSiren project
- Enable branch protection on main (requires PR + passing Cerberus tests)

### Hooks
- **pre-commit**: blocks commits on `main` and on merged branches
- **pre-push**: blocks direct pushes to `main`, validates branch naming (`feat/`, `fix/`, etc.), checks for uncommitted files, runs full test suite, checks for merge conflicts with main

### Branch Protection
- Required status checks: `test (18)`, `test (20)`, `test (22)` from Cerberus
- Force pushes and branch deletion disabled
- PRs required (0 approvals since solo project)

## Test plan
- [x] All 90 tests pass via pre-push hook
- [ ] Verify Cerberus CI runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)